### PR TITLE
Extract deploy logic into a standalone shell script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,26 +71,16 @@ jobs:
           MARIADB_ROOT_PASSWORD: ${{ secrets.MARIADB_ROOT_PASSWORD }}
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
 
-      - name: Deploy site
+      - name: Update repo on server
         run: |
           ssh droplet "set -e &&
             if [ ! -d /root/portfolio/.git ]; then
               git clone https://github.com/dddictionary/portfolio.git /root/portfolio
             fi &&
             cd /root/portfolio &&
-            git fetch && git reset origin/main --hard &&
+            git fetch && git reset origin/main --hard"
 
-            # Create shared networks (idempotent)
-            docker network create portfolio_net 2>/dev/null || true &&
-            docker network create monitoring_net 2>/dev/null || true &&
-
-            # Authenticate with GHCR and pull the latest image
-            echo '${GHCR_PAT}' | docker login ghcr.io -u dddictionary --password-stdin &&
-            docker compose -f docker-compose.prod.yml pull &&
-
-            # Restart services (three independent stacks)
-            docker compose -f docker-compose.prod.yml up -d &&
-            docker compose -f docker-compose.monitoring.yml up -d &&
-            docker compose -f docker-compose.router.yml up -d"
+      - name: Deploy site
+        run: ssh droplet "GHCR_PAT='${GHCR_PAT}' bash /root/portfolio/scripts/deploy.sh"
         env:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /root/portfolio
+
+# ── Create shared networks (idempotent) ──────────────────────────────
+docker network create portfolio_net 2>/dev/null || true
+docker network create monitoring_net 2>/dev/null || true
+
+# ── Authenticate with GHCR ───────────────────────────────────────────
+echo "${GHCR_PAT}" | docker login ghcr.io -u dddictionary --password-stdin
+
+# ── Pull and restart all stacks ──────────────────────────────────────
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.monitoring.yml up -d
+docker compose -f docker-compose.router.yml up -d


### PR DESCRIPTION
Moves the deploy commands out of the inline GitHub Actions SSH
block and into scripts/deploy.sh for easier local testing and
maintenance. The workflow now clones/pulls the repo first, then
runs the script from the updated checkout.