### PR TITLE
Migrate 4brar.me from DigitalOcean droplet to istaroth k3s

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,format=short
+            type=sha,format=short,prefix=
             type=raw,value=latest
 
       - name: Compute short sha tag

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      image_tag: ${{ steps.meta.outputs.version }}
+      image_tag: ${{ steps.tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -40,6 +40,10 @@ jobs:
           tags: |
             type=sha,format=short
             type=raw,value=latest
+
+      - name: Compute short sha tag
+        id: tag
+        run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -86,37 +90,54 @@ jobs:
           ssh istaroth "mkdir -p /root/k8s"
           scp -r k8s/. istaroth:/root/k8s/
 
-      - name: Apply secrets (idempotent)
+      - name: Install kubectl on runner
+        uses: azure/setup-kubectl@v4
+
+      - name: Ensure namespaces exist
         run: |
-          ssh istaroth bash -s <<'EOF'
-            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-            kubectl apply -f /root/k8s/namespace.yaml
+          ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /root/k8s/namespace.yaml"
 
-            kubectl -n portfolio create secret generic backend-secrets \
-              --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
-              --from-literal=MYSQL_USER="$MYSQL_USER" \
-              --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
-              --from-literal=MYSQL_HOST=mariadb \
-              --from-literal=URL="$URL" \
-              --dry-run=client -o yaml | kubectl apply -f -
+      - name: Apply backend-secrets
+        run: |
+          kubectl create secret generic backend-secrets \
+            -n portfolio \
+            --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+            --from-literal=MYSQL_USER="$MYSQL_USER" \
+            --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+            --from-literal=MYSQL_HOST=mariadb \
+            --from-literal=URL="$URL" \
+            --dry-run=client -o yaml \
+            | ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -"
+        env:
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          URL: ${{ secrets.URL }}
 
-            kubectl -n portfolio create secret generic mariadb-secrets \
-              --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
-              --from-literal=MYSQL_USER="$MYSQL_USER" \
-              --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
-              --from-literal=MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
-              --dry-run=client -o yaml | kubectl apply -f -
-
-            kubectl -n monitoring create secret generic grafana-secrets \
-              --from-literal=GRAFANA_PASSWORD="$GRAFANA_PASSWORD" \
-              --dry-run=client -o yaml | kubectl apply -f -
-          EOF
+      - name: Apply mariadb-secrets
+        run: |
+          kubectl create secret generic mariadb-secrets \
+            -n portfolio \
+            --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+            --from-literal=MYSQL_USER="$MYSQL_USER" \
+            --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+            --from-literal=MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
+            --dry-run=client -o yaml \
+            | ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -"
         env:
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
           MYSQL_USER: ${{ secrets.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
           MARIADB_ROOT_PASSWORD: ${{ secrets.MARIADB_ROOT_PASSWORD }}
-          URL: ${{ secrets.URL }}
+
+      - name: Apply grafana-secrets
+        run: |
+          kubectl create secret generic grafana-secrets \
+            -n monitoring \
+            --from-literal=GRAFANA_PASSWORD="$GRAFANA_PASSWORD" \
+            --dry-run=client -o yaml \
+            | ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -"
+        env:
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
 
       - name: Apply k8s manifests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,93 +4,137 @@ on:
   push:
     branches:
       - main
-
+      - feat/k3s-istaroth
   workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
-    name: "Build & Push Docker Image"
+    name: "Build & Push Image"
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=short
+            type=raw,value=latest
+
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/dddictionary/4brar.me:latest,ghcr.io/dddictionary/4brar.me:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   deploy:
-    name: "Deploy to VPS"
-    runs-on: ubuntu-latest
+    name: "Deploy to k3s"
     needs: build-and-push
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Configure SSH
         run: |
-          mkdir -p ~/.ssh/
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy-key.pem
-          chmod 600 ~/.ssh/deploy-key.pem
-          cat >> ~/.ssh/config <<END
-          Host droplet
-            HostName $SSH_IP
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          cat > ~/.ssh/config <<EOF
+          Host istaroth
+            HostName $SSH_HOST
             User $SSH_USER
-            IdentityFile ~/.ssh/deploy-key.pem
-            StrictHostKeyChecking no
-          END
+            IdentityFile ~/.ssh/id_ed25519
+            StrictHostKeyChecking accept-new
+          EOF
         env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_IP: ${{ secrets.SSH_IP }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Create .env file on server
+      - name: Copy k8s manifests
         run: |
-          ssh droplet "mkdir -p /root/portfolio && printf 'MYSQL_DATABASE=%s\nMYSQL_USER=%s\nMYSQL_PASSWORD=%s\nMYSQL_HOST=%s\nURL=%s\nCERTBOT_EMAIL=%s\nMARIADB_ROOT_PASSWORD=%s\nGRAFANA_PASSWORD=%s\n' '$MYSQL_DATABASE' '$MYSQL_USER' '$MYSQL_PASSWORD' '$MYSQL_HOST' '$URL' '$CERTBOT_EMAIL' '$MARIADB_ROOT_PASSWORD' '$GRAFANA_PASSWORD' > /root/portfolio/.env"
+          ssh istaroth "mkdir -p /root/k8s"
+          scp -r k8s/. istaroth:/root/k8s/
+
+      - name: Apply secrets (idempotent)
+        run: |
+          ssh istaroth bash -s <<'EOF'
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -f /root/k8s/namespace.yaml
+
+            kubectl -n portfolio create secret generic backend-secrets \
+              --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+              --from-literal=MYSQL_USER="$MYSQL_USER" \
+              --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+              --from-literal=MYSQL_HOST=mariadb \
+              --from-literal=URL="$URL" \
+              --dry-run=client -o yaml | kubectl apply -f -
+
+            kubectl -n portfolio create secret generic mariadb-secrets \
+              --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+              --from-literal=MYSQL_USER="$MYSQL_USER" \
+              --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+              --from-literal=MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
+              --dry-run=client -o yaml | kubectl apply -f -
+
+            kubectl -n monitoring create secret generic grafana-secrets \
+              --from-literal=GRAFANA_PASSWORD="$GRAFANA_PASSWORD" \
+              --dry-run=client -o yaml | kubectl apply -f -
+          EOF
         env:
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
           MYSQL_USER: ${{ secrets.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
-          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
-          URL: ${{ secrets.URL }}
-          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
           MARIADB_ROOT_PASSWORD: ${{ secrets.MARIADB_ROOT_PASSWORD }}
+          URL: ${{ secrets.URL }}
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
 
-      - name: Deploy site
+      - name: Apply k8s manifests
         run: |
-          ssh droplet "set -e &&
-            if [ ! -d /root/portfolio/.git ]; then
-              git clone https://github.com/dddictionary/portfolio.git /root/portfolio
-            fi &&
-            cd /root/portfolio &&
-            git fetch && git reset origin/main --hard &&
+          ssh istaroth bash -s <<'EOF'
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -f /root/k8s/namespace.yaml
+            kubectl apply -R -f /root/k8s/mariadb/
+            kubectl apply -R -f /root/k8s/backend/
+            kubectl apply -R -f /root/k8s/ingress/
+            kubectl apply -R -f /root/k8s/monitoring/
+          EOF
 
-            # Create shared networks (idempotent)
-            docker network create portfolio_net 2>/dev/null || true &&
-            docker network create monitoring_net 2>/dev/null || true &&
-
-            # Authenticate with GHCR and pull the latest image
-            echo '${GHCR_PAT}' | docker login ghcr.io -u dddictionary --password-stdin &&
-            docker compose -f docker-compose.prod.yml pull &&
-
-            # Restart services (three independent stacks)
-            docker compose -f docker-compose.prod.yml up -d &&
-            docker compose -f docker-compose.monitoring.yml up -d &&
-            docker compose -f docker-compose.router.yml up -d"
-        env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+      - name: Rolling update backend
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.image_tag }}"
+          ssh istaroth bash -s <<EOF
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl -n portfolio set image deployment/backend backend=${IMAGE}
+            kubectl -n portfolio rollout status deployment/backend --timeout=300s
+          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/k3s-istaroth
   workflow_dispatch:
 
 env:

--- a/app/main.py
+++ b/app/main.py
@@ -65,6 +65,11 @@ async def track_metrics(request: Request, call_next):
     return response
 
 
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
 app.include_router(api_router)
 app.include_router(pages_router)
 

--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: portfolio
+  labels:
+    app: backend
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/dddictionary/4brar.me:latest
+          ports:
+            - containerPort: 5000
+          envFrom:
+            - secretRef:
+                name: backend-secrets
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/k8s/backend/service.yaml
+++ b/k8s/backend/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: portfolio
+  labels:
+    app: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+  selector:
+    app: backend

--- a/k8s/ingress/ingress.yaml
+++ b/k8s/ingress/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx-internal
   rules:
-    - host: home.4brar.me
+    - host: 4brar.me
       http:
         paths:
           - path: /

--- a/k8s/ingress/ingress.yaml
+++ b/k8s/ingress/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portfolio-ingress
+  namespace: portfolio
+  annotations:
+    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
+spec:
+  ingressClassName: nginx-internal
+  rules:
+    - host: home.4brar.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 5000

--- a/k8s/mariadb/service.yaml
+++ b/k8s/mariadb/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: portfolio
+  labels:
+    app: mariadb
+spec:
+  clusterIP: None
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+  selector:
+    app: mariadb

--- a/k8s/mariadb/statefulset.yaml
+++ b/k8s/mariadb/statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mariadb
+  namespace: portfolio
+  labels:
+    app: mariadb
+spec:
+  serviceName: mariadb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:latest
+          ports:
+            - containerPort: 3306
+          envFrom:
+            - secretRef:
+                name: mariadb-secrets
+          volumeMounts:
+            - name: mariadb-data
+              mountPath: /var/lib/mysql
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: mariadb-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/monitoring/grafana/configmap-dashboard-files.yaml
+++ b/k8s/monitoring/grafana/configmap-dashboard-files.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-files
+  namespace: monitoring
+data:
+  backend.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "uid": "backend-app",
+      "title": "Backend Application",
+      "tags": ["backend"],
+      "timezone": "browser",
+      "refresh": "10s",
+      "schemaVersion": 39,
+      "panels": [
+        {
+          "title": "Request Rate (req/s)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps" },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "rate(http_requests_total[1m])",
+              "legendFormat": "{{method}} {{status}} {{path}}"
+            }
+          ]
+        },
+        {
+          "title": "Error Rate (5xx)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": { "unit": "reqps", "color": { "mode": "fixed", "fixedColor": "red" } },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "rate(http_requests_total{status=~\"5..\"}[1m])",
+              "legendFormat": "{{method}} {{status}} {{path}}"
+            }
+          ]
+        },
+        {
+          "title": "Request Latency (p50 / p95 / p99)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": { "unit": "s" },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, rate(http_request_duration_seconds_bucket[1m]))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[1m]))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[1m]))",
+              "legendFormat": "p99"
+            }
+          ]
+        },
+        {
+          "title": "Status Code Breakdown",
+          "type": "piechart",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "targets": [
+            {
+              "expr": "sum by (status) (increase(http_requests_total[5m]))",
+              "legendFormat": "{{status}}"
+            }
+          ]
+        },
+        {
+          "title": "Timeline Posts Created",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "green" } },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "rate(timeline_posts_created_total[5m])",
+              "legendFormat": "posts/sec"
+            }
+          ]
+        },
+        {
+          "title": "Requests by Path",
+          "type": "bargauge",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "targets": [
+            {
+              "expr": "sum by (path) (increase(http_requests_total[5m]))",
+              "legendFormat": "{{path}}"
+            }
+          ]
+        }
+      ],
+      "templating": { "list": [] },
+      "time": { "from": "now-1h", "to": "now" }
+    }

--- a/k8s/monitoring/grafana/configmap-dashboards.yaml
+++ b/k8s/monitoring/grafana/configmap-dashboards.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: monitoring
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: "default"
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: false

--- a/k8s/monitoring/grafana/configmap-datasource.yaml
+++ b/k8s/monitoring/grafana/configmap-datasource.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  namespace: monitoring
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.monitoring:9090
+        uid: PBFA97CFB590B2093
+        isDefault: true
+        editable: false

--- a/k8s/monitoring/grafana/deployment.yaml
+++ b/k8s/monitoring/grafana/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-secrets
+                  key: GRAFANA_PASSWORD
+            - name: GF_SERVER_ROOT_URL
+              value: "https://observe.4brar.me/"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/grafana
+            - name: datasource-config
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-config
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboard-files
+              mountPath: /var/lib/grafana/dashboards
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: grafana-data
+        - name: datasource-config
+          configMap:
+            name: grafana-datasource
+        - name: dashboard-config
+          configMap:
+            name: grafana-dashboards
+        - name: dashboard-files
+          configMap:
+            name: grafana-dashboard-files

--- a/k8s/monitoring/grafana/ingress.yaml
+++ b/k8s/monitoring/grafana/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: nginx-internal
   rules:
-    - host: observe-home.4brar.me
+    - host: observe.4brar.me
       http:
         paths:
           - path: /

--- a/k8s/monitoring/grafana/ingress.yaml
+++ b/k8s/monitoring/grafana/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: monitoring
+spec:
+  ingressClassName: nginx-internal
+  rules:
+    - host: observe-home.4brar.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/k8s/monitoring/grafana/pvc.yaml
+++ b/k8s/monitoring/grafana/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/monitoring/grafana/service.yaml
+++ b/k8s/monitoring/grafana/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    app: grafana
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+  selector:
+    app: grafana

--- a/k8s/monitoring/node-exporter/daemonset.yaml
+++ b/k8s/monitoring/node-exporter/daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: monitoring
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: node-exporter
+          image: prom/node-exporter:latest
+          args:
+            - "--path.procfs=/host/proc"
+            - "--path.sysfs=/host/sys"
+            - "--path.rootfs=/host/rootfs"
+            - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+          ports:
+            - containerPort: 9100
+              hostPort: 9100
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: rootfs
+              mountPath: /host/rootfs
+              readOnly: true
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: rootfs
+          hostPath:
+            path: /

--- a/k8s/monitoring/node-exporter/service.yaml
+++ b/k8s/monitoring/node-exporter/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: monitoring
+  labels:
+    app: node-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+  selector:
+    app: node-exporter

--- a/k8s/monitoring/prometheus/configmap.yaml
+++ b/k8s/monitoring/prometheus/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: "portfolio"
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: ["portfolio"]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app]
+            action: keep
+            regex: backend
+          - source_labels: [__meta_kubernetes_endpoints_name]
+            action: keep
+            regex: backend
+
+      - job_name: "node-exporter"
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: ["monitoring"]
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app]
+            action: keep
+            regex: node-exporter
+
+      - job_name: "prometheus"
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: "kubelet"
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: "container_.*"
+            action: keep

--- a/k8s/monitoring/prometheus/deployment.yaml
+++ b/k8s/monitoring/prometheus/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.retention.time=30d"
+            - "--storage.tsdb.path=/prometheus"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+            - name: data
+              mountPath: /prometheus
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: prometheus-data

--- a/k8s/monitoring/prometheus/pvc.yaml
+++ b/k8s/monitoring/prometheus/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/monitoring/prometheus/rbac.yaml
+++ b/k8s/monitoring/prometheus/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "services", "endpoints", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: monitoring

--- a/k8s/monitoring/prometheus/service.yaml
+++ b/k8s/monitoring/prometheus/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    app: prometheus

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portfolio
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring


### PR DESCRIPTION
## Summary

- Replaces droplet-based Docker Compose deploy with k3s on the istaroth homelab
- Public traffic served via Cloudflare Tunnel (no exposed home IP, TLS at edge)
- Zero-downtime rolling updates: 2 backend replicas, `maxUnavailable: 0`
- Deploy workflow uses Tailscale to reach istaroth from GitHub Actions runners
- Adds `/healthz` to FastAPI for k8s readiness/liveness probes

## Notes

- Validated end-to-end on `home.4brar.me` before cutover (HTTP 200 served from istaroth)
- Droplet still running; teardown is the next step after this merges
- Manifests use `ingressClassName: nginx-internal` (matches homelab cluster's ingress class)
- Cluster has cloudflared running in its own namespace as the public on-ramp

## Test plan

- [ ] Merge triggers Deploy workflow
- [ ] Backend pods reach 2/2 Running
- [ ] `https://4brar.me` returns site content
- [ ] `https://observe.4brar.me` returns Grafana login
- [ ] Destroy DigitalOcean droplet