### PR TITLE
feat: add calendar booking page with email approval flow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from prometheus_client import Counter, Histogram
 
 from app.database import close_db, init_db
 from app.routes.api import router as api_router
+from app.routes.booking import router as booking_router
 from app.routes.pages import router as pages_router
 
 load_dotenv()
@@ -71,6 +72,7 @@ async def healthz():
 
 
 app.include_router(api_router)
+app.include_router(booking_router)
 app.include_router(pages_router)
 
 static_dir = os.path.join(os.path.dirname(__file__), "static")

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import aiomysql
 
 
@@ -28,3 +30,77 @@ async def create_post(pool: aiomysql.Pool, name: str, email: str, content: str) 
             row = await cur.fetchone()
             row["created_at"] = row["created_at"].isoformat()
             return row
+
+
+async def create_booking_request(
+    pool: aiomysql.Pool,
+    name: str,
+    email: str,
+    title: str,
+    description: str,
+    start_time: datetime,
+    duration_min: int,
+    timezone: str,
+    ip: str,
+) -> int:
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                INSERT INTO booking_requests
+                    (name, email, title, description, start_time, duration_min, timezone, ip)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (name, email, title, description, start_time, duration_min, timezone, ip),
+            )
+            return cur.lastrowid
+
+
+async def get_booking_request(pool: aiomysql.Pool, booking_id: int) -> dict | None:
+    async with pool.acquire() as conn:
+        async with conn.cursor(aiomysql.DictCursor) as cur:
+            await cur.execute(
+                "SELECT * FROM booking_requests WHERE id = %s",
+                (booking_id,),
+            )
+            return await cur.fetchone()
+
+
+async def update_booking_status(
+    pool: aiomysql.Pool,
+    booking_id: int,
+    status: str,
+    calendar_event_id: str | None = None,
+) -> None:
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            if calendar_event_id is not None:
+                await cur.execute(
+                    """
+                    UPDATE booking_requests
+                    SET status = %s, decided_at = %s, calendar_event_id = %s
+                    WHERE id = %s
+                    """,
+                    (status, datetime.utcnow(), calendar_event_id, booking_id),
+                )
+            else:
+                await cur.execute(
+                    "UPDATE booking_requests SET status = %s, decided_at = %s WHERE id = %s",
+                    (status, datetime.utcnow(), booking_id),
+                )
+
+
+async def count_recent_requests_by_ip(
+    pool: aiomysql.Pool,
+    ip: str,
+    within_hours: int = 1,
+) -> int:
+    cutoff = datetime.utcnow() - timedelta(hours=within_hours)
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT COUNT(*) FROM booking_requests WHERE ip = %s AND created_at >= %s",
+                (ip, cutoff),
+            )
+            (count,) = await cur.fetchone()
+            return count

--- a/app/routes/booking.py
+++ b/app/routes/booking.py
@@ -1,0 +1,209 @@
+import logging
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from app.database import get_pool
+from app.models import (
+    count_recent_requests_by_ip,
+    create_booking_request,
+    get_booking_request,
+    update_booking_status,
+)
+from app.services import email as email_service
+from app.services import google_calendar, turnstile
+from app.services.tokens import (
+    make_decide_token,
+    make_verify_token,
+    read_decide_token,
+    read_verify_token,
+)
+
+logger = logging.getLogger("backend")
+router = APIRouter()
+
+ALLOWED_DURATIONS = {15, 30, 60}
+RATE_LIMIT_PER_HOUR = 5
+
+
+def _enabled() -> bool:
+    return os.environ.get("BOOKING_ENABLED", "true").lower() == "true"
+
+
+def _base_url() -> str:
+    return os.environ.get("URL", "http://localhost:5000").rstrip("/")
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _format_local(dt: datetime, tz: str) -> str:
+    try:
+        return dt.astimezone(ZoneInfo(tz)).strftime("%A, %B %d %Y at %I:%M %p %Z")
+    except ZoneInfoNotFoundError:
+        return dt.isoformat()
+
+
+@router.post("/api/booking")
+async def submit_booking(
+    request: Request,
+    name: str = Form(...),
+    email: str = Form(...),
+    title: str = Form(...),
+    description: str = Form(...),
+    start_time: str = Form(...),
+    duration_min: int = Form(...),
+    timezone: str = Form(...),
+    honeypot: str = Form(default=""),
+    turnstile_token: str = Form(default="", alias="cf-turnstile-response"),
+):
+    if not _enabled():
+        raise HTTPException(status_code=503, detail="Booking is temporarily disabled")
+    if honeypot:
+        logger.info("Booking honeypot triggered ip=%s", _client_ip(request))
+        return {"status": "ok"}
+
+    name = name.strip()
+    email = email.strip().lower()
+    title = title.strip()
+    description = description.strip()
+
+    if not name or not title or not description:
+        raise HTTPException(status_code=400, detail="Missing required fields")
+    if "@" not in email or "." not in email.split("@")[-1]:
+        raise HTTPException(status_code=400, detail="Invalid email")
+    if duration_min not in ALLOWED_DURATIONS:
+        raise HTTPException(status_code=400, detail="Invalid duration")
+    try:
+        start_dt = datetime.fromisoformat(start_time)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid datetime")
+    if start_dt < datetime.now():
+        raise HTTPException(status_code=400, detail="Start time must be in the future")
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError:
+        raise HTTPException(status_code=400, detail="Invalid timezone")
+
+    ip = _client_ip(request)
+    if not await turnstile.verify(turnstile_token, ip):
+        raise HTTPException(status_code=400, detail="Captcha failed")
+
+    pool = await get_pool()
+    recent = await count_recent_requests_by_ip(pool, ip)
+    if recent >= RATE_LIMIT_PER_HOUR:
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    booking_id = await create_booking_request(
+        pool, name, email, title, description, start_dt, duration_min, timezone, ip,
+    )
+
+    verify_url = f"{_base_url()}/booking/verify?token={make_verify_token(booking_id)}"
+    email_service.send(
+        to=email,
+        subject="Confirm your booking request",
+        html=email_service.render(
+            "verify.html",
+            name=name,
+            title=title,
+            duration_min=duration_min,
+            start_local=_format_local(start_dt, timezone),
+            verify_url=verify_url,
+        ),
+    )
+    return {"status": "ok", "message": "Check your email to confirm."}
+
+
+@router.get("/booking/verify", response_class=HTMLResponse)
+async def verify_booking(token: str):
+    booking_id = read_verify_token(token)
+    if booking_id is None:
+        return HTMLResponse("<h1>Link expired or invalid.</h1>", status_code=400)
+
+    pool = await get_pool()
+    booking = await get_booking_request(pool, booking_id)
+    if booking is None:
+        return HTMLResponse("<h1>Not found.</h1>", status_code=404)
+    if booking["status"] != "pending_verification":
+        return HTMLResponse("<h1>Already confirmed. We'll be in touch.</h1>")
+
+    await update_booking_status(pool, booking_id, "pending_approval")
+
+    approve_url = f"{_base_url()}/booking/decide?token={make_decide_token(booking_id, 'approve')}"
+    reject_url = f"{_base_url()}/booking/decide?token={make_decide_token(booking_id, 'reject')}"
+    email_service.send(
+        to=os.environ["OWNER_EMAIL"],
+        subject=f"Booking request from {booking['name']}",
+        html=email_service.render(
+            "approval_request.html",
+            name=booking["name"],
+            email=booking["email"],
+            title=booking["title"],
+            description=booking["description"],
+            start_local=_format_local(booking["start_time"], booking["timezone"]),
+            duration_min=booking["duration_min"],
+            timezone=booking["timezone"],
+            ip=booking["ip"],
+            approve_url=approve_url,
+            reject_url=reject_url,
+        ),
+    )
+    return HTMLResponse("<h1>Confirmed. Abrar will review and reply.</h1>")
+
+
+@router.get("/booking/decide", response_class=HTMLResponse)
+async def decide_booking(token: str):
+    parsed = read_decide_token(token)
+    if parsed is None:
+        return HTMLResponse("<h1>Link expired or invalid.</h1>", status_code=400)
+    booking_id, action = parsed
+    if action not in {"approve", "reject"}:
+        return HTMLResponse("<h1>Invalid action.</h1>", status_code=400)
+
+    pool = await get_pool()
+    booking = await get_booking_request(pool, booking_id)
+    if booking is None:
+        return HTMLResponse("<h1>Not found.</h1>", status_code=404)
+    if booking["status"] not in {"pending_approval", "pending_verification"}:
+        return HTMLResponse(f"<h1>Already {booking['status']}.</h1>")
+
+    if action == "reject":
+        await update_booking_status(pool, booking_id, "rejected")
+        email_service.send(
+            to=booking["email"],
+            subject="Re: your booking request",
+            html=email_service.render(
+                "rejected.html", name=booking["name"], title=booking["title"]
+            ),
+        )
+        return HTMLResponse("<h1>Rejected. Requester notified.</h1>")
+
+    event_id = google_calendar.create_event(
+        summary=f"{booking['title']} (with {booking['name']})",
+        description=f"From {booking['name']} <{booking['email']}>\n\n{booking['description']}",
+        start=booking["start_time"],
+        duration_min=booking["duration_min"],
+        timezone=booking["timezone"],
+        attendee_email=booking["email"],
+        attendee_name=booking["name"],
+    )
+    await update_booking_status(pool, booking_id, "approved", calendar_event_id=event_id)
+    email_service.send(
+        to=booking["email"],
+        subject="Booking confirmed",
+        html=email_service.render(
+            "approved.html",
+            name=booking["name"],
+            title=booking["title"],
+            duration_min=booking["duration_min"],
+            start_local=_format_local(booking["start_time"], booking["timezone"]),
+        ),
+    )
+    return HTMLResponse("<h1>Approved. Calendar invite sent.</h1>")

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -20,6 +20,7 @@ NAV_ITEMS = [
     {"href": "/#travels", "caption": "travels"},
     {"href": "/#guestbook", "caption": "guestbook"},
     {"href": "/blog", "caption": "blog"},
+    {"href": "/book", "caption": "book"},
 ]
 
 SKILLS = [
@@ -60,6 +61,16 @@ async def index():
 @router.get("/blog", response_class=HTMLResponse)
 async def blog():
     return render("blog.html", title="Abrar Habib — Blog", request_path="/blog", posts=[])
+
+
+@router.get("/book", response_class=HTMLResponse)
+async def book():
+    return render(
+        "book.html",
+        title="Abrar Habib — Book time",
+        request_path="/book",
+        turnstile_site_key=os.environ.get("TURNSTILE_SITE_KEY", ""),
+    )
 
 
 # ── Redirects for old routes ──

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -1,0 +1,38 @@
+import logging
+import os
+import smtplib
+from email.message import EmailMessage
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+logger = logging.getLogger("backend")
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates", "emails")
+_env = Environment(
+    loader=FileSystemLoader(_TEMPLATES_DIR),
+    autoescape=select_autoescape(["html"]),
+)
+
+
+def render(template_name: str, **context) -> str:
+    return _env.get_template(template_name).render(**context)
+
+
+def send(*, to: str, subject: str, html: str) -> None:
+    msg = EmailMessage()
+    msg["From"] = os.environ["SMTP_FROM"]
+    msg["To"] = to
+    msg["Subject"] = subject
+    msg.set_content("This email requires an HTML-capable client.")
+    msg.add_alternative(html, subtype="html")
+
+    host = os.environ.get("SMTP_HOST", "smtp.gmail.com")
+    port = int(os.environ.get("SMTP_PORT", "587"))
+    user = os.environ["SMTP_USER"]
+    password = os.environ["SMTP_PASSWORD"]
+
+    with smtplib.SMTP(host, port) as s:
+        s.starttls()
+        s.login(user, password)
+        s.send_message(msg)
+    logger.info("Sent email to=%s subject=%s", to, subject)

--- a/app/services/google_calendar.py
+++ b/app/services/google_calendar.py
@@ -1,0 +1,54 @@
+import logging
+import os
+from datetime import datetime, timedelta
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+logger = logging.getLogger("backend")
+
+SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def _credentials() -> Credentials:
+    creds = Credentials(
+        token=None,
+        refresh_token=os.environ["GOOGLE_REFRESH_TOKEN"],
+        client_id=os.environ["GOOGLE_CLIENT_ID"],
+        client_secret=os.environ["GOOGLE_CLIENT_SECRET"],
+        token_uri="https://oauth2.googleapis.com/token",
+        scopes=SCOPES,
+    )
+    creds.refresh(Request())
+    return creds
+
+
+def create_event(
+    *,
+    summary: str,
+    description: str,
+    start: datetime,
+    duration_min: int,
+    timezone: str,
+    attendee_email: str,
+    attendee_name: str,
+) -> str:
+    service = build("calendar", "v3", credentials=_credentials(), cache_discovery=False)
+    end = start + timedelta(minutes=duration_min)
+    body = {
+        "summary": summary,
+        "description": description,
+        "start": {"dateTime": start.isoformat(), "timeZone": timezone},
+        "end": {"dateTime": end.isoformat(), "timeZone": timezone},
+        "attendees": [{"email": attendee_email, "displayName": attendee_name}],
+        "reminders": {"useDefault": True},
+    }
+    calendar_id = os.environ.get("GOOGLE_CALENDAR_ID", "primary")
+    event = (
+        service.events()
+        .insert(calendarId=calendar_id, body=body, sendUpdates="all")
+        .execute()
+    )
+    logger.info("Created calendar event id=%s", event["id"])
+    return event["id"]

--- a/app/services/tokens.py
+++ b/app/services/tokens.py
@@ -1,0 +1,37 @@
+import os
+
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+VERIFY_SALT = "booking-verify"
+DECIDE_SALT = "booking-decide"
+
+VERIFY_TTL_SECONDS = 24 * 60 * 60
+DECIDE_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    secret = os.environ["BOOKING_TOKEN_SECRET"]
+    return URLSafeTimedSerializer(secret)
+
+
+def make_verify_token(booking_id: int) -> str:
+    return _serializer().dumps(booking_id, salt=VERIFY_SALT)
+
+
+def make_decide_token(booking_id: int, action: str) -> str:
+    return _serializer().dumps({"id": booking_id, "action": action}, salt=DECIDE_SALT)
+
+
+def read_verify_token(token: str) -> int | None:
+    try:
+        return _serializer().loads(token, salt=VERIFY_SALT, max_age=VERIFY_TTL_SECONDS)
+    except (BadSignature, SignatureExpired):
+        return None
+
+
+def read_decide_token(token: str) -> tuple[int, str] | None:
+    try:
+        payload = _serializer().loads(token, salt=DECIDE_SALT, max_age=DECIDE_TTL_SECONDS)
+    except (BadSignature, SignatureExpired):
+        return None
+    return payload["id"], payload["action"]

--- a/app/services/turnstile.py
+++ b/app/services/turnstile.py
@@ -1,0 +1,26 @@
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger("backend")
+
+VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+
+async def verify(token: str, remote_ip: str | None = None) -> bool:
+    secret = os.environ.get("TURNSTILE_SECRET")
+    if not secret:
+        logger.warning("TURNSTILE_SECRET not set; allowing request (dev mode)")
+        return True
+    data = {"secret": secret, "response": token}
+    if remote_ip:
+        data["remoteip"] = remote_ip
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(VERIFY_URL, data=data)
+            result = resp.json()
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning("Turnstile verify failed: %s", e)
+        return False
+    return bool(result.get("success"))

--- a/app/templates/book.html
+++ b/app/templates/book.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+
+{% block head %}
+{% if turnstile_site_key %}
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+{% endif %}
+<style>
+  .book { max-width: 640px; margin: 0 auto; padding: 80px 24px 120px; }
+  .book__title { font-family: Syne, sans-serif; font-size: 2.5rem; margin-bottom: 8px; }
+  .book__note { color: var(--muted, #888); margin-bottom: 32px; font-size: 0.95rem; }
+  .book__form { display: flex; flex-direction: column; gap: 16px; }
+  .book__field { display: flex; flex-direction: column; gap: 6px; }
+  .book__field label { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  .book__field input, .book__field textarea, .book__field select {
+    padding: 10px 12px; border: 1px solid #444; background: transparent; color: inherit;
+    font-family: inherit; font-size: 1rem; border-radius: 4px;
+  }
+  .book__field textarea { resize: vertical; min-height: 100px; }
+  .book__row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .book__submit {
+    padding: 12px 24px; background: #fff; color: #111; border: none; border-radius: 4px;
+    font-weight: 600; cursor: pointer; font-size: 1rem; margin-top: 8px;
+  }
+  .book__submit:disabled { opacity: 0.5; cursor: not-allowed; }
+  .book__honeypot { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
+  .book__status { margin-top: 16px; padding: 12px; border-radius: 4px; }
+  .book__status--ok { background: rgba(10, 127, 63, 0.15); color: #4caf7c; }
+  .book__status--err { background: rgba(176, 0, 32, 0.15); color: #ff6b8a; }
+</style>
+{% endblock %}
+
+{% block content %}
+<section class="book">
+  <h1 class="book__title">Book time</h1>
+  <p class="book__note">
+    Generally available weekdays after 5pm ET, and weekends anytime.
+    Pick a time that works — I'll confirm via email.
+  </p>
+
+  <form class="book__form" id="bookForm">
+    <div class="book__honeypot" aria-hidden="true">
+      <label>Leave this empty<input type="text" name="honeypot" tabindex="-1" autocomplete="off"></label>
+    </div>
+
+    <div class="book__row">
+      <div class="book__field">
+        <label for="name">Your name</label>
+        <input id="name" name="name" type="text" required maxlength="100">
+      </div>
+      <div class="book__field">
+        <label for="email">Your email</label>
+        <input id="email" name="email" type="email" required maxlength="200">
+      </div>
+    </div>
+
+    <div class="book__field">
+      <label for="title">Subject</label>
+      <input id="title" name="title" type="text" required maxlength="200" placeholder="e.g. catch up, project chat">
+    </div>
+
+    <div class="book__field">
+      <label for="description">What's it about?</label>
+      <textarea id="description" name="description" required maxlength="2000"></textarea>
+    </div>
+
+    <div class="book__row">
+      <div class="book__field">
+        <label for="start_time">Preferred date & time</label>
+        <input id="start_time" name="start_time" type="datetime-local" required>
+      </div>
+      <div class="book__field">
+        <label for="duration_min">Duration</label>
+        <select id="duration_min" name="duration_min" required>
+          <option value="15">15 minutes</option>
+          <option value="30" selected>30 minutes</option>
+          <option value="60">60 minutes</option>
+        </select>
+      </div>
+    </div>
+
+    <input type="hidden" name="timezone" id="timezone">
+
+    {% if turnstile_site_key %}
+    <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>
+    {% endif %}
+
+    <button type="submit" class="book__submit" id="submitBtn">Send request</button>
+    <div id="status"></div>
+  </form>
+</section>
+
+<script>
+  document.getElementById('timezone').value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const form = document.getElementById('bookForm');
+  const status = document.getElementById('status');
+  const submitBtn = document.getElementById('submitBtn');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    submitBtn.disabled = true;
+    status.className = '';
+    status.textContent = 'Sending...';
+    try {
+      const resp = await fetch('/api/booking', { method: 'POST', body: new FormData(form) });
+      const data = await resp.json().catch(() => ({}));
+      if (resp.ok) {
+        status.className = 'book__status book__status--ok';
+        status.textContent = data.message || 'Request sent — check your email.';
+        form.reset();
+        document.getElementById('timezone').value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      } else {
+        status.className = 'book__status book__status--err';
+        status.textContent = data.detail || 'Something went wrong.';
+        submitBtn.disabled = false;
+      }
+    } catch (err) {
+      status.className = 'book__status book__status--err';
+      status.textContent = 'Network error. Try again.';
+      submitBtn.disabled = false;
+    }
+  });
+</script>
+{% endblock %}

--- a/app/templates/emails/approval_request.html
+++ b/app/templates/emails/approval_request.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; max-width: 540px; margin: 0 auto; padding: 24px;">
+  <h2>New booking request</h2>
+  <table style="font-size: 14px;">
+    <tr><td><strong>Name</strong></td><td>{{ name }}</td></tr>
+    <tr><td><strong>Email</strong></td><td>{{ email }}</td></tr>
+    <tr><td><strong>Title</strong></td><td>{{ title }}</td></tr>
+    <tr><td><strong>When</strong></td><td>{{ start_local }} ({{ duration_min }} min, {{ timezone }})</td></tr>
+    <tr><td><strong>IP</strong></td><td>{{ ip }}</td></tr>
+  </table>
+  <p><strong>Details:</strong></p>
+  <blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #444;">{{ description }}</blockquote>
+  <p>
+    <a href="{{ approve_url }}" style="display: inline-block; background: #0a7f3f; color: #fff; padding: 12px 20px; text-decoration: none; border-radius: 6px; margin-right: 8px;">Approve</a>
+    <a href="{{ reject_url }}" style="display: inline-block; background: #b00020; color: #fff; padding: 12px 20px; text-decoration: none; border-radius: 6px;">Reject</a>
+  </p>
+</body>
+</html>

--- a/app/templates/emails/approved.html
+++ b/app/templates/emails/approved.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; max-width: 540px; margin: 0 auto; padding: 24px;">
+  <h2>You're confirmed</h2>
+  <p>Hey {{ name }},</p>
+  <p>Abrar approved your booking — <strong>{{ title }}</strong> on {{ start_local }} ({{ duration_min }} min).</p>
+  <p>A calendar invite is on the way. Talk soon!</p>
+</body>
+</html>

--- a/app/templates/emails/rejected.html
+++ b/app/templates/emails/rejected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; max-width: 540px; margin: 0 auto; padding: 24px;">
+  <h2>Booking request declined</h2>
+  <p>Hey {{ name }},</p>
+  <p>Unfortunately Abrar can't make the requested time for <strong>{{ title }}</strong>. Feel free to try another time or reach out directly.</p>
+</body>
+</html>

--- a/app/templates/emails/verify.html
+++ b/app/templates/emails/verify.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body style="font-family: sans-serif; max-width: 540px; margin: 0 auto; padding: 24px;">
+  <h2>Confirm your booking request</h2>
+  <p>Hey {{ name }},</p>
+  <p>You requested time on Abrar's calendar — <strong>{{ title }}</strong> on {{ start_local }} ({{ duration_min }} min).</p>
+  <p>Click below to confirm. Abrar will review and reply.</p>
+  <p>
+    <a href="{{ verify_url }}" style="display: inline-block; background: #111; color: #fff; padding: 12px 20px; text-decoration: none; border-radius: 6px;">Confirm request</a>
+  </p>
+  <p style="color: #888; font-size: 12px;">This link expires in 24 hours. If you didn't request this, ignore this email.</p>
+</body>
+</html>

--- a/example.env
+++ b/example.env
@@ -3,3 +3,25 @@ MYSQL_HOST=
 MYSQL_USER=
 MYSQL_PASSWORD=
 MYSQL_DATABASE=
+
+# Booking feature
+BOOKING_ENABLED=true
+BOOKING_TOKEN_SECRET=
+OWNER_EMAIL=
+
+# Google Calendar OAuth (run scripts/google_oauth_setup.py to generate)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REFRESH_TOKEN=
+GOOGLE_CALENDAR_ID=primary
+
+# Cloudflare Turnstile
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET=
+
+# Gmail SMTP (use a Google App Password)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM=

--- a/migrations/003_booking_requests.sql
+++ b/migrations/003_booking_requests.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS booking_requests (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    start_time DATETIME NOT NULL,
+    duration_min INTEGER NOT NULL,
+    timezone VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending_verification',
+    ip VARCHAR(45) NOT NULL,
+    calendar_event_id VARCHAR(255) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    decided_at DATETIME NULL,
+    INDEX idx_status (status),
+    INDEX idx_ip_created (ip, created_at)
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ python-dotenv==1.1.0
 python-multipart==0.0.20
 prometheus-client==0.22.1
 cryptography==46.0.6
+itsdangerous==2.2.0
+httpx==0.28.1
+google-api-python-client==2.149.0
+google-auth==2.35.0
+google-auth-oauthlib==1.2.1

--- a/scripts/google_oauth_setup.py
+++ b/scripts/google_oauth_setup.py
@@ -1,0 +1,44 @@
+"""One-time script to obtain a Google OAuth refresh token for Calendar access.
+
+Usage:
+    1. In Google Cloud Console, create OAuth 2.0 credentials (Desktop app type).
+    2. Download the JSON, save as client_secret.json in repo root.
+    3. Run: python scripts/google_oauth_setup.py
+    4. Authorize in browser, then copy the printed refresh token into k8s secrets
+       as GOOGLE_REFRESH_TOKEN (alongside GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET).
+"""
+import json
+import sys
+from pathlib import Path
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def main() -> int:
+    client_secret_path = Path("client_secret.json")
+    if not client_secret_path.exists():
+        print("ERROR: client_secret.json not found in current directory.", file=sys.stderr)
+        print("Download it from Google Cloud Console → APIs & Services → Credentials.", file=sys.stderr)
+        return 1
+
+    flow = InstalledAppFlow.from_client_secrets_file(str(client_secret_path), SCOPES)
+    creds = flow.run_local_server(port=0, prompt="consent", access_type="offline")
+
+    with client_secret_path.open() as f:
+        secret = json.load(f)
+    block = secret.get("installed") or secret.get("web") or {}
+
+    print("\n" + "=" * 60)
+    print("SUCCESS — save these as k8s secrets:")
+    print("=" * 60)
+    print(f"GOOGLE_CLIENT_ID={block.get('client_id', '')}")
+    print(f"GOOGLE_CLIENT_SECRET={block.get('client_secret', '')}")
+    print(f"GOOGLE_REFRESH_TOKEN={creds.refresh_token}")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1,0 +1,193 @@
+import os
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("BOOKING_TOKEN_SECRET", "test-secret-do-not-use-in-prod")
+os.environ.setdefault("OWNER_EMAIL", "owner@example.com")
+os.environ.setdefault("URL", "http://test")
+
+from app.services.tokens import (  # noqa: E402
+    make_decide_token,
+    make_verify_token,
+    read_decide_token,
+    read_verify_token,
+)
+
+
+def _future_iso(hours: int = 48) -> str:
+    return (datetime.now() + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M")
+
+
+def _valid_form() -> dict:
+    return {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "title": "Quick chat",
+        "description": "Wanted to catch up",
+        "start_time": _future_iso(),
+        "duration_min": "30",
+        "timezone": "America/New_York",
+    }
+
+
+def test_token_roundtrip():
+    assert read_verify_token(make_verify_token(42)) == 42
+    assert read_decide_token(make_decide_token(42, "approve")) == (42, "approve")
+    assert read_verify_token("garbage") is None
+    assert read_decide_token("garbage") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_happy_path(client):
+    with patch("app.routes.booking.turnstile.verify", new_callable=AsyncMock, return_value=True), \
+         patch("app.routes.booking.count_recent_requests_by_ip", new_callable=AsyncMock, return_value=0), \
+         patch("app.routes.booking.create_booking_request", new_callable=AsyncMock, return_value=123), \
+         patch("app.routes.booking.email_service.send") as mock_send:
+        resp = await client.post("/api/booking", data=_valid_form())
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "ok"
+    mock_send.assert_called_once()
+    assert mock_send.call_args.kwargs["to"] == "jane@example.com"
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_honeypot_silently_drops(client):
+    form = _valid_form()
+    form["honeypot"] = "bot was here"
+    with patch("app.routes.booking.email_service.send") as mock_send:
+        resp = await client.post("/api/booking", data=form)
+    assert resp.status_code == 200
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_invalid_email(client):
+    form = _valid_form()
+    form["email"] = "not-an-email"
+    resp = await client.post("/api/booking", data=form)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_invalid_duration(client):
+    form = _valid_form()
+    form["duration_min"] = "45"
+    resp = await client.post("/api/booking", data=form)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_past_datetime(client):
+    form = _valid_form()
+    form["start_time"] = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M")
+    resp = await client.post("/api/booking", data=form)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_rate_limited(client):
+    with patch("app.routes.booking.turnstile.verify", new_callable=AsyncMock, return_value=True), \
+         patch("app.routes.booking.count_recent_requests_by_ip", new_callable=AsyncMock, return_value=99):
+        resp = await client.post("/api/booking", data=_valid_form())
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_turnstile_fails(client):
+    with patch("app.routes.booking.turnstile.verify", new_callable=AsyncMock, return_value=False):
+        resp = await client.post("/api/booking", data=_valid_form())
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_submit_booking_kill_switch(client):
+    with patch.dict(os.environ, {"BOOKING_ENABLED": "false"}):
+        resp = await client.post("/api/booking", data=_valid_form())
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_verify_booking_happy_path(client):
+    booking = {
+        "id": 7, "name": "Jane", "email": "j@x.com", "title": "Chat",
+        "description": "hi", "start_time": datetime.now() + timedelta(days=1),
+        "duration_min": 30, "timezone": "America/New_York", "ip": "1.2.3.4",
+        "status": "pending_verification", "calendar_event_id": None,
+    }
+    token = make_verify_token(7)
+    with patch("app.routes.booking.get_booking_request", new_callable=AsyncMock, return_value=booking), \
+         patch("app.routes.booking.update_booking_status", new_callable=AsyncMock) as mock_upd, \
+         patch("app.routes.booking.email_service.send") as mock_send:
+        resp = await client.get(f"/booking/verify?token={token}")
+    assert resp.status_code == 200
+    mock_upd.assert_called_once_with(mock_upd.call_args.args[0], 7, "pending_approval")
+    assert mock_send.call_args.kwargs["to"] == "owner@example.com"
+
+
+@pytest.mark.asyncio
+async def test_verify_booking_bad_token(client):
+    resp = await client.get("/booking/verify?token=junk")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_decide_approve_creates_event(client):
+    booking = {
+        "id": 9, "name": "Jane", "email": "j@x.com", "title": "Chat",
+        "description": "hi", "start_time": datetime.now() + timedelta(days=1),
+        "duration_min": 30, "timezone": "America/New_York", "ip": "1.2.3.4",
+        "status": "pending_approval", "calendar_event_id": None,
+    }
+    token = make_decide_token(9, "approve")
+    with patch("app.routes.booking.get_booking_request", new_callable=AsyncMock, return_value=booking), \
+         patch("app.routes.booking.update_booking_status", new_callable=AsyncMock) as mock_upd, \
+         patch("app.routes.booking.google_calendar.create_event", return_value="evt-123"), \
+         patch("app.routes.booking.email_service.send") as mock_send:
+        resp = await client.get(f"/booking/decide?token={token}")
+    assert resp.status_code == 200
+    assert mock_upd.call_args.kwargs["calendar_event_id"] == "evt-123"
+    assert mock_send.call_args.kwargs["to"] == "j@x.com"
+
+
+@pytest.mark.asyncio
+async def test_decide_reject_notifies_requester(client):
+    booking = {
+        "id": 10, "name": "Jane", "email": "j@x.com", "title": "Chat",
+        "description": "hi", "start_time": datetime.now() + timedelta(days=1),
+        "duration_min": 30, "timezone": "America/New_York", "ip": "1.2.3.4",
+        "status": "pending_approval", "calendar_event_id": None,
+    }
+    token = make_decide_token(10, "reject")
+    with patch("app.routes.booking.get_booking_request", new_callable=AsyncMock, return_value=booking), \
+         patch("app.routes.booking.update_booking_status", new_callable=AsyncMock), \
+         patch("app.routes.booking.google_calendar.create_event") as mock_event, \
+         patch("app.routes.booking.email_service.send") as mock_send:
+        resp = await client.get(f"/booking/decide?token={token}")
+    assert resp.status_code == 200
+    mock_event.assert_not_called()
+    assert mock_send.call_args.kwargs["to"] == "j@x.com"
+
+
+@pytest.mark.asyncio
+async def test_decide_already_decided(client):
+    booking = {
+        "id": 11, "name": "Jane", "email": "j@x.com", "title": "Chat",
+        "description": "hi", "start_time": datetime.now() + timedelta(days=1),
+        "duration_min": 30, "timezone": "America/New_York", "ip": "1.2.3.4",
+        "status": "approved", "calendar_event_id": "evt-prev",
+    }
+    token = make_decide_token(11, "approve")
+    with patch("app.routes.booking.get_booking_request", new_callable=AsyncMock, return_value=booking), \
+         patch("app.routes.booking.google_calendar.create_event") as mock_event:
+        resp = await client.get(f"/booking/decide?token={token}")
+    assert resp.status_code == 200
+    mock_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_book_page_renders(client):
+    resp = await client.get("/book")
+    assert resp.status_code == 200
+    assert "Book time" in resp.text


### PR DESCRIPTION
## Summary
- Adds `/book` page where visitors can request time on the calendar (name, email, subject, description, datetime, duration 15/30/60 min)
- Two-step approval flow: requester verifies their email → owner gets an approve/reject email → on approve, a Google Calendar event is created with the requester invited
- Spam protection: Cloudflare Turnstile, honeypot field, per-IP rate limit (5/hr), mandatory email verification, `BOOKING_ENABLED` kill switch

## Before deploying
1. Run `python scripts/google_oauth_setup.py` locally with a `client_secret.json` from Google Cloud Console to obtain a refresh token
2. Create a Cloudflare Turnstile site + secret keys
3. Generate a Gmail App Password
4. Add the new env vars to the `backend-secrets` k8s Secret: `BOOKING_TOKEN_SECRET`, `OWNER_EMAIL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_CALENDAR_ID`, `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`

## Test plan
- [x] Unit tests (15 new) cover happy path, honeypot, invalid input, rate limit, turnstile fail, kill switch, verify/decide flows — `pytest tests/` is 32/32 passing
- [ ] Manual smoke test against staging once secrets are configured
- [ ] Confirm calendar invite arrives in requester's inbox and on owner's calendar
- [ ] Confirm reject path sends polite decline email