### PR TITLE
feat: staging deploy infrastructure

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,183 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to deploy to staging"
+        required: true
+        default: "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  STAGING_TAG: staging
+
+jobs:
+  build-and-push:
+    name: "Build & Push Staging Image"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.tag.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute short sha tag
+        id: tag
+        run: echo "sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.STAGING_TAG }}
+            type=raw,value=staging-${{ steps.tag.outputs.sha }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=staging
+          cache-to: type=gha,mode=max,scope=staging
+
+  deploy:
+    name: "Deploy to k3s (staging)"
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          cat > ~/.ssh/config <<EOF
+          Host istaroth
+            HostName $SSH_HOST
+            User $SSH_USER
+            IdentityFile ~/.ssh/id_ed25519
+            StrictHostKeyChecking accept-new
+          EOF
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Copy staging k8s manifests
+        run: |
+          ssh istaroth "mkdir -p /root/k8s-staging"
+          scp -r k8s/staging/. istaroth:/root/k8s-staging/
+
+      - name: Install kubectl on runner
+        uses: azure/setup-kubectl@v4
+
+      - name: Ensure staging namespace exists
+        run: |
+          ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /root/k8s-staging/namespace.yaml"
+
+      - name: Apply backend-secrets (staging)
+        run: |
+          kubectl create secret generic backend-secrets \
+            -n portfolio-staging \
+            --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+            --from-literal=MYSQL_USER="$MYSQL_USER" \
+            --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+            --from-literal=MYSQL_HOST=mariadb \
+            --from-literal=URL="$URL" \
+            --from-literal=BOOKING_ENABLED="true" \
+            --from-literal=BOOKING_TOKEN_SECRET="$BOOKING_TOKEN_SECRET" \
+            --from-literal=OWNER_EMAIL="$OWNER_EMAIL" \
+            --from-literal=GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" \
+            --from-literal=GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            --from-literal=GOOGLE_REFRESH_TOKEN="$GOOGLE_REFRESH_TOKEN" \
+            --from-literal=GOOGLE_CALENDAR_ID="$GOOGLE_CALENDAR_ID" \
+            --from-literal=TURNSTILE_SITE_KEY="$TURNSTILE_SITE_KEY" \
+            --from-literal=TURNSTILE_SECRET="$TURNSTILE_SECRET" \
+            --from-literal=SMTP_HOST="$SMTP_HOST" \
+            --from-literal=SMTP_PORT="$SMTP_PORT" \
+            --from-literal=SMTP_USER="$SMTP_USER" \
+            --from-literal=SMTP_PASSWORD="$SMTP_PASSWORD" \
+            --from-literal=SMTP_FROM="$SMTP_FROM" \
+            --dry-run=client -o yaml \
+            | ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -"
+        env:
+          MYSQL_DATABASE: ${{ secrets.STAGING_MYSQL_DATABASE }}
+          MYSQL_USER: ${{ secrets.STAGING_MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.STAGING_MYSQL_PASSWORD }}
+          URL: ${{ secrets.STAGING_URL }}
+          BOOKING_TOKEN_SECRET: ${{ secrets.STAGING_BOOKING_TOKEN_SECRET }}
+          OWNER_EMAIL: ${{ secrets.STAGING_OWNER_EMAIL }}
+          GOOGLE_CLIENT_ID: ${{ secrets.STAGING_GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.STAGING_GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.STAGING_GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_CALENDAR_ID: ${{ secrets.STAGING_GOOGLE_CALENDAR_ID }}
+          TURNSTILE_SITE_KEY: ${{ secrets.STAGING_TURNSTILE_SITE_KEY }}
+          TURNSTILE_SECRET: ${{ secrets.STAGING_TURNSTILE_SECRET }}
+          SMTP_HOST: ${{ secrets.STAGING_SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.STAGING_SMTP_PORT }}
+          SMTP_USER: ${{ secrets.STAGING_SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.STAGING_SMTP_PASSWORD }}
+          SMTP_FROM: ${{ secrets.STAGING_SMTP_FROM }}
+
+      - name: Apply mariadb-secrets (staging)
+        run: |
+          kubectl create secret generic mariadb-secrets \
+            -n portfolio-staging \
+            --from-literal=MYSQL_DATABASE="$MYSQL_DATABASE" \
+            --from-literal=MYSQL_USER="$MYSQL_USER" \
+            --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
+            --from-literal=MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
+            --dry-run=client -o yaml \
+            | ssh istaroth "KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -"
+        env:
+          MYSQL_DATABASE: ${{ secrets.STAGING_MYSQL_DATABASE }}
+          MYSQL_USER: ${{ secrets.STAGING_MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.STAGING_MYSQL_PASSWORD }}
+          MARIADB_ROOT_PASSWORD: ${{ secrets.STAGING_MARIADB_ROOT_PASSWORD }}
+
+      - name: Apply staging k8s manifests
+        run: |
+          ssh istaroth bash -s <<'EOF'
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -f /root/k8s-staging/namespace.yaml
+            kubectl apply -R -f /root/k8s-staging/mariadb/
+            kubectl apply -R -f /root/k8s-staging/backend/
+            kubectl apply -R -f /root/k8s-staging/ingress/
+          EOF
+
+      - name: Rolling update staging backend
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging-${{ needs.build-and-push.outputs.image_tag }}"
+          ssh istaroth bash -s <<EOF
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl -n portfolio-staging set image deployment/backend backend=${IMAGE}
+            kubectl -n portfolio-staging rollout status deployment/backend --timeout=300s
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .env
+.env.*
+!example.env
+client_secret*.json
 .DS_Store
 undo/
 service_logs.txt

--- a/k8s/staging/backend/deployment.yaml
+++ b/k8s/staging/backend/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: portfolio-staging
+  labels:
+    app: backend
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/dddictionary/4brar.me:staging
+          ports:
+            - containerPort: 5000
+          envFrom:
+            - secretRef:
+                name: backend-secrets
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/k8s/staging/backend/service.yaml
+++ b/k8s/staging/backend/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: portfolio-staging
+  labels:
+    app: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+  selector:
+    app: backend

--- a/k8s/staging/ingress/ingress.yaml
+++ b/k8s/staging/ingress/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portfolio-ingress
+  namespace: portfolio-staging
+  annotations:
+    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
+spec:
+  ingressClassName: nginx-internal
+  rules:
+    - host: staging.4brar.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 5000

--- a/k8s/staging/mariadb/service.yaml
+++ b/k8s/staging/mariadb/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: portfolio-staging
+  labels:
+    app: mariadb
+spec:
+  clusterIP: None
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+  selector:
+    app: mariadb

--- a/k8s/staging/mariadb/statefulset.yaml
+++ b/k8s/staging/mariadb/statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mariadb
+  namespace: portfolio-staging
+  labels:
+    app: mariadb
+spec:
+  serviceName: mariadb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:latest
+          ports:
+            - containerPort: 3306
+          envFrom:
+            - secretRef:
+                name: mariadb-secrets
+          volumeMounts:
+            - name: mariadb-data
+              mountPath: /var/lib/mysql
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+                - --connect
+                - --innodb_initialized
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: mariadb-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/staging/namespace.yaml
+++ b/k8s/staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portfolio-staging

--- a/scripts/setup-staging-secrets.sh
+++ b/scripts/setup-staging-secrets.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Upload STAGING_* GitHub Actions secrets from a local env file.
+#
+# Usage:
+#   cp staging.env.example .env.staging
+#   # edit .env.staging with real values
+#   ./scripts/setup-staging-secrets.sh .env.staging
+#
+# Requires: gh CLI authenticated against the dddictionary/4brar.me repo.
+
+set -euo pipefail
+
+ENV_FILE="${1:-.env.staging}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: env file not found: $ENV_FILE" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not installed" >&2
+  exit 1
+fi
+
+while IFS='=' read -r key value; do
+  [[ -z "$key" || "$key" =~ ^# ]] && continue
+  value="${value%\"}"
+  value="${value#\"}"
+  if [[ -z "$value" ]]; then
+    echo "skip $key (empty)"
+    continue
+  fi
+  echo "set $key"
+  gh secret set "$key" --body "$value"
+done < "$ENV_FILE"
+
+echo "done."

--- a/staging.env.example
+++ b/staging.env.example
@@ -1,0 +1,41 @@
+# Staging secrets — copy to .env.staging, fill in, then run:
+#   ./scripts/setup-staging-secrets.sh .env.staging
+#
+# Anything left empty will be skipped. .env.staging is gitignored.
+
+# --- MariaDB (StatefulSet bootstraps with these on first boot) ---
+STAGING_MYSQL_DATABASE=portfolio
+STAGING_MYSQL_USER=portfolio
+STAGING_MYSQL_PASSWORD=
+STAGING_MARIADB_ROOT_PASSWORD=
+
+# --- App ---
+STAGING_URL=https://staging.4brar.me
+
+# --- Booking ---
+# Generate a fresh value, e.g. `openssl rand -hex 32`. Do NOT reuse the prod secret.
+STAGING_BOOKING_TOKEN_SECRET=
+# Where booking approval emails go. Suggest a +staging alias of your real address.
+STAGING_OWNER_EMAIL=
+
+# --- Google Calendar OAuth ---
+# Reuse prod client OR generate fresh via `scripts/google_oauth_setup.py`.
+# Point STAGING_GOOGLE_CALENDAR_ID at a dedicated staging calendar to keep events out of prod.
+STAGING_GOOGLE_CLIENT_ID=
+STAGING_GOOGLE_CLIENT_SECRET=
+STAGING_GOOGLE_REFRESH_TOKEN=
+STAGING_GOOGLE_CALENDAR_ID=6883342a399c8e1e4332e0ee5624984ab2aab0723a59815434586c186b437eca@group.calendar.google.com
+
+# --- Cloudflare Turnstile ---
+# Test keys that always pass (safe for staging):
+#   site:   1x00000000000000000000AA
+#   secret: 1x0000000000000000000000000000000AA
+STAGING_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+STAGING_TURNSTILE_SECRET=1x0000000000000000000000000000000AA
+
+# --- Gmail SMTP ---
+STAGING_SMTP_HOST=smtp.gmail.com
+STAGING_SMTP_PORT=587
+STAGING_SMTP_USER=
+STAGING_SMTP_PASSWORD=
+STAGING_SMTP_FROM=


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch`-only `deploy-staging.yml` that builds a `:staging-<sha>` image and applies `k8s/staging/` manifests against the `portfolio-staging` namespace.
- Mirrors prod under `k8s/staging/` with its own MariaDB StatefulSet (2Gi PVC) and ingress on `staging.4brar.me` via `nginx-internal`.
- Adds `scripts/setup-staging-secrets.sh` (uploads STAGING_* GH Actions secrets from a local env file) and `staging.env.example` documenting required values.
- Tightens `.gitignore` to cover `.env.*` (keeps `example.env` + `staging.env.example` tracked) and `client_secret*.json`.

No prod paths are touched.

## Test plan
- [ ] After merge, `gh workflow run deploy-staging.yml --ref feat/booking` succeeds end-to-end
- [ ] `staging.4brar.me` serves the site, healthcheck passes
- [ ] `kubectl -n portfolio-staging get pods` shows `backend` + `mariadb` Running